### PR TITLE
In-app notifications, file picker

### DIFF
--- a/ios/Beamlet/App/BeamletApp.swift
+++ b/ios/Beamlet/App/BeamletApp.swift
@@ -81,7 +81,12 @@ struct BeamletApp: App {
 
 // MARK: - App Delegate (Push Notifications)
 
-class AppDelegate: NSObject, UIApplicationDelegate {
+class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        return true
+    }
+
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         let token = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
         UserDefaults(suiteName: "group.com.beamlet.shared")?.set(token, forKey: "apnsDeviceToken")
@@ -90,6 +95,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         print("Failed to register for push: \(error)")
+    }
+
+    // Show notifications even when app is in foreground
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.banner, .sound, .badge])
     }
 }
 

--- a/ios/Beamlet/Presentation/Send/SendView.swift
+++ b/ios/Beamlet/Presentation/Send/SendView.swift
@@ -1,12 +1,14 @@
 import SwiftUI
 import PhotosUI
 import AudioToolbox
+import UniformTypeIdentifiers
 
 struct SendView: View {
     @Environment(BeamletAPI.self) private var api
     @Environment(NearbyService.self) private var nearbyService: NearbyService?
     @State private var viewModel: SendViewModel?
     @State private var showSendAnimation = false
+    @State private var showFilePicker = false
 
     var body: some View {
         NavigationStack {
@@ -107,11 +109,36 @@ struct SendView: View {
                             }
                         }
                         .onChange(of: vm.selectedPhoto) {
+                            vm.selectedFileURL = nil // Clear file if photo selected
                             Task { await vm.loadPhotoData() }
+                        }
+
+                        Button {
+                            showFilePicker = true
+                        } label: {
+                            HStack {
+                                Image(systemName: vm.selectedFileURL != nil ? "checkmark.circle.fill" : "doc")
+                                    .foregroundStyle(vm.selectedFileURL != nil ? .green : .secondary)
+                                Text(vm.selectedFileName ?? "Choose file")
+                            }
                         }
 
                         TextField("Message (optional)", text: Bindable(vm).message, axis: .vertical)
                             .lineLimit(3...6)
+                    }
+                    .fileImporter(
+                        isPresented: $showFilePicker,
+                        allowedContentTypes: [.item],
+                        allowsMultipleSelection: false
+                    ) { result in
+                        if case .success(let urls) = result, let url = urls.first {
+                            _ = url.startAccessingSecurityScopedResource()
+                            vm.selectedFileURL = url
+                            vm.selectedFileName = url.lastPathComponent
+                            vm.selectedFileMimeType = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType
+                            vm.selectedPhoto = nil
+                            vm.selectedPhotoData = nil
+                        }
                     }
 
                     if let error = vm.error {

--- a/ios/Beamlet/Presentation/Send/SendViewModel.swift
+++ b/ios/Beamlet/Presentation/Send/SendViewModel.swift
@@ -12,12 +12,15 @@ class SendViewModel {
     var message = ""
     var selectedPhoto: PhotosPickerItem?
     var selectedPhotoData: Data?
+    var selectedFileURL: URL?
+    var selectedFileName: String?
+    var selectedFileMimeType: String?
     var isSending = false
     var error: String?
     var showSuccess = false
 
     var canSend: Bool {
-        !selectedUsers.isEmpty && (selectedPhotoData != nil || !message.isEmpty) && !isSending
+        !selectedUsers.isEmpty && (selectedPhotoData != nil || selectedFileURL != nil || !message.isEmpty) && !isSending
     }
 
     func toggleUser(_ user: BeamletUser) {
@@ -60,6 +63,15 @@ class SendViewModel {
                         mimeType: "image/jpeg",
                         message: message.isEmpty ? nil : message
                     )
+                } else if let fileURL = selectedFileURL {
+                    let fileData = try Data(contentsOf: fileURL)
+                    let _ = try await api.uploadFile(
+                        recipientID: userID,
+                        fileData: fileData,
+                        filename: selectedFileName ?? fileURL.lastPathComponent,
+                        mimeType: selectedFileMimeType ?? "application/octet-stream",
+                        message: message.isEmpty ? nil : message
+                    )
                 } else if !message.isEmpty {
                     let _ = try await api.uploadText(
                         recipientID: userID,
@@ -78,6 +90,9 @@ class SendViewModel {
         selectedUsers.removeAll()
         selectedPhoto = nil
         selectedPhotoData = nil
+        selectedFileURL = nil
+        selectedFileName = nil
+        selectedFileMimeType = nil
         message = ""
     }
 }


### PR DESCRIPTION
Shows push banners in foreground. Send tab supports files and documents alongside photos.